### PR TITLE
persistent-postgresql is not actually used

### DIFF
--- a/servant-auth-token-persistent/servant-auth-token-persistent.cabal
+++ b/servant-auth-token-persistent/servant-auth-token-persistent.cabal
@@ -29,7 +29,6 @@ library
     , monad-control           >= 1.0    && < 1.1
     , mtl                     >= 2.2    && < 2.3
     , persistent              >= 2.2    && < 2.7
-    , persistent-postgresql   >= 2.2    && < 2.7
     , persistent-template     >= 2.1    && < 2.7
     , servant-server          >= 0.9    && < 0.10
     , servant-auth-token      >= 0.4    && < 0.5


### PR DESCRIPTION
Whilst you need to choose a backend when wanting to _use_
servant-auth-token-persistent, the library itself is agnostic as to
choice.