### PR TITLE
Make withAuthToken work properly

### DIFF
--- a/servant-auth-token.cabal
+++ b/servant-auth-token.cabal
@@ -59,7 +59,7 @@ library
     Servant.Server.Auth.Token.Restore
     Servant.Server.Auth.Token.SingleUse
   build-depends:
-      base                    >= 4.7    && < 5
+      base                    >= 4.8    && < 5
     , aeson-injector          >= 1.0.4  && < 1.1
     , bytestring              >= 0.10   && < 0.11
     , containers              >= 0.5    && < 0.6

--- a/src/Servant/Server/Auth/Token.hs
+++ b/src/Servant/Server/Auth/Token.hs
@@ -484,7 +484,7 @@ class WithAuthToken a where
 instance (AuthHandler m) => WithAuthToken (m a) where
   withAuthToken m mt = guardAuthToken mt *> m
 
-instance (WithAuthToken r) => WithAuthToken (a -> r) where
+instance {-# OVERLAPPING #-} (WithAuthToken r) => WithAuthToken (a -> r) where
   withAuthToken f mt = (`withAuthToken` mt) . f
 
 instance (WithAuthToken a, WithAuthToken b) => WithAuthToken (a :<|> b) where


### PR DESCRIPTION
(Fixes the issue arising in #8 where - since `((->) a)` is a Monad -
the `(m a)` and `(a -> r)` instances could not be decided between.)

Note that because GHC 7.10 changed the preference from the top-level
`LANGUAGE` pragma to a more instance-specific pragma, the minimum
version of base had to be bumped (otherwise CPP hackery would be
needed).

This works by putting a higher priority on the explicit function instance than allowing functions to be treated as Monads (since I highly doubt a function will be a valid `AuthHandler` instance).

The best bit is, is that the API hasn't changed! So only a bug-fix version bump is needed for this.