### PR TITLE
Use explicit instances for ConvertStorage

### DIFF
--- a/servant-auth-token-persistent/servant-auth-token-persistent.cabal
+++ b/servant-auth-token-persistent/servant-auth-token-persistent.cabal
@@ -25,7 +25,6 @@ library
     , aeson-injector          >= 1.0    && < 1.1
     , bytestring              >= 0.10   && < 0.11
     , containers              >= 0.5    && < 0.6
-    , ghc-prim                >= 0.5    && < 0.6
     , monad-control           >= 1.0    && < 1.1
     , mtl                     >= 2.2    && < 2.3
     , persistent              >= 2.2    && < 2.7

--- a/servant-auth-token-persistent/src/Servant/Server/Auth/Token/Persistent/Schema.hs
+++ b/servant-auth-token-persistent/src/Servant/Server/Auth/Token/Persistent/Schema.hs
@@ -1,15 +1,17 @@
-{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE DefaultSignatures, RecordWildCards #-}
 module Servant.Server.Auth.Token.Persistent.Schema where
 
 import Data.Text
 import Data.Time
+import Database.Persist.Sql (Key, SqlBackend, ToBackendKey, fromSqlKey,
+                             toSqlKey)
 import Database.Persist.TH
-import GHC.Generics
-import GHC.Prim
+import GHC.Generics         (Generic)
 
-import Servant.API.Auth.Token
-
-import qualified Servant.Server.Auth.Token.Model as M
+import           Servant.API.Auth.Token
+import           Servant.Server.Auth.Token.Common (ConvertableKey, fromKey,
+                                                   toKey)
+import qualified Servant.Server.Auth.Token.Model  as M
 
 share [mkPersist sqlSettings
      , mkDeleteCascade sqlSettings
@@ -61,19 +63,111 @@ AuthUserGroupPerms
 class ConvertStorage a b | a -> b, b -> a where
   -- | Convert to internal representation
   convertTo   :: b -> a
-  convertTo = unsafeCoerce#
+  default convertTo :: (ToBackendKey SqlBackend r, a ~ Key r, ConvertableKey b) => b -> a
+  convertTo = toSqlKey . fromKey
+
   -- | Convert from internal representation
   convertFrom :: a -> b
-  convertFrom = unsafeCoerce#
+  default convertFrom :: (ToBackendKey SqlBackend r, a ~ Key r, ConvertableKey b) => a -> b
+  convertFrom = toKey . fromSqlKey
 
-instance ConvertStorage UserImpl M.UserImpl
-instance ConvertStorage UserPerm M.UserPerm
-instance ConvertStorage AuthToken M.AuthToken
-instance ConvertStorage UserRestore M.UserRestore
-instance ConvertStorage UserSingleUseCode M.UserSingleUseCode
-instance ConvertStorage AuthUserGroup M.AuthUserGroup
-instance ConvertStorage AuthUserGroupUsers M.AuthUserGroupUsers
-instance ConvertStorage AuthUserGroupPerms M.AuthUserGroupPerms
+instance ConvertStorage UserImpl M.UserImpl where
+  convertTo M.UserImpl{..} =
+    UserImpl { userImplLogin    = userImplLogin
+             , userImplPassword = userImplPassword
+             , userImplEmail    = userImplEmail
+             }
+
+  convertFrom UserImpl{..} =
+    M.UserImpl { userImplLogin    = userImplLogin
+               , userImplPassword = userImplPassword
+               , userImplEmail    = userImplEmail
+               }
+
+instance ConvertStorage UserPerm M.UserPerm where
+  convertTo M.UserPerm{..} =
+    UserPerm { userPermUser       = convertTo userPermUser
+             , userPermPermission = userPermPermission
+             }
+
+  convertFrom UserPerm{..} =
+    M.UserPerm { userPermUser       = convertFrom userPermUser
+               , userPermPermission = userPermPermission
+               }
+
+instance ConvertStorage AuthToken M.AuthToken where
+  convertTo M.AuthToken{..} =
+    AuthToken { authTokenValue  = authTokenValue
+              , authTokenUser   = convertTo authTokenUser
+              , authTokenExpire = authTokenExpire
+              }
+
+  convertFrom AuthToken{..} =
+    M.AuthToken { authTokenValue  = authTokenValue
+                , authTokenUser   = convertFrom authTokenUser
+                , authTokenExpire = authTokenExpire
+                }
+
+instance ConvertStorage UserRestore M.UserRestore where
+  convertTo M.UserRestore{..} =
+    UserRestore { userRestoreValue  = userRestoreValue
+                , userRestoreUser   = convertTo userRestoreUser
+                , userRestoreExpire = userRestoreExpire
+                }
+
+  convertFrom UserRestore{..} =
+    M.UserRestore { userRestoreValue  = userRestoreValue
+                  , userRestoreUser   = convertFrom userRestoreUser
+                  , userRestoreExpire = userRestoreExpire
+                  }
+
+instance ConvertStorage UserSingleUseCode M.UserSingleUseCode where
+  convertTo M.UserSingleUseCode{..} =
+    UserSingleUseCode { userSingleUseCodeValue  = userSingleUseCodeValue
+                      , userSingleUseCodeUser   = convertTo userSingleUseCodeUser
+                      , userSingleUseCodeExpire = userSingleUseCodeExpire
+                      , userSingleUseCodeUsed   = userSingleUseCodeUsed
+                      }
+
+  convertFrom UserSingleUseCode{..} =
+    M.UserSingleUseCode { userSingleUseCodeValue  = userSingleUseCodeValue
+                        , userSingleUseCodeUser   = convertFrom userSingleUseCodeUser
+                        , userSingleUseCodeExpire = userSingleUseCodeExpire
+                        , userSingleUseCodeUsed   = userSingleUseCodeUsed
+                        }
+
+instance ConvertStorage AuthUserGroup M.AuthUserGroup where
+  convertTo M.AuthUserGroup{..} =
+    AuthUserGroup { authUserGroupName   = authUserGroupName
+                  , authUserGroupParent = convertTo <$> authUserGroupParent
+                  }
+
+  convertFrom AuthUserGroup{..} =
+    M.AuthUserGroup { authUserGroupName   = authUserGroupName
+                    , authUserGroupParent = convertFrom <$> authUserGroupParent
+                    }
+
+instance ConvertStorage AuthUserGroupUsers M.AuthUserGroupUsers where
+  convertTo M.AuthUserGroupUsers{..} =
+    AuthUserGroupUsers { authUserGroupUsersGroup = convertTo authUserGroupUsersGroup
+                       , authUserGroupUsersUser  = convertTo authUserGroupUsersUser
+                       }
+
+  convertFrom AuthUserGroupUsers{..} =
+    M.AuthUserGroupUsers { authUserGroupUsersGroup = convertFrom authUserGroupUsersGroup
+                         , authUserGroupUsersUser  = convertFrom authUserGroupUsersUser
+                         }
+
+instance ConvertStorage AuthUserGroupPerms M.AuthUserGroupPerms where
+  convertTo M.AuthUserGroupPerms{..} =
+    AuthUserGroupPerms { authUserGroupPermsGroup      = convertTo authUserGroupPermsGroup
+                       , authUserGroupPermsPermission = authUserGroupPermsPermission
+                       }
+
+  convertFrom AuthUserGroupPerms{..} =
+    M.AuthUserGroupPerms { authUserGroupPermsGroup      = convertFrom authUserGroupPermsGroup
+                         , authUserGroupPermsPermission = authUserGroupPermsPermission
+                         }
 
 instance ConvertStorage UserImplId M.UserImplId
 instance ConvertStorage UserPermId M.UserPermId


### PR DESCRIPTION
The usage of unsafeCoerce# did not seem to work well when dealing with
the Key-based fields from persistent in compiled code.

Unfortunately, I couldn't come up with an automated approach that worked for all of these (Generics may have been possible, but would have needed instances for every type referenced as well, so thought it wasn't worth the bother) so I had to go with manual instances for the most part and use default instances for the keys.

Closes #12