### PR TITLE
Rename the persistent migration function

### DIFF
--- a/example/persistent/src/Monad.hs
+++ b/example/persistent/src/Monad.hs
@@ -43,7 +43,7 @@ newServerEnv cfg = do
   pool <- liftIO $ do
     pool <- createPool cfg
     -- run migrations
-    flip runSqlPool pool $ runMigration S.migrateAll
+    flip runSqlPool pool $ runMigration S.migrateAllAuth
     -- create default admin if missing one
     _ <- runPersistentBackendT authConfig pool $ ensureAdmin 17 "admin" "123456" "admin@localhost"
     return pool

--- a/servant-auth-token-persistent/README.md
+++ b/servant-auth-token-persistent/README.md
@@ -25,7 +25,7 @@ newServerEnv cfg = do
   pool <- liftIO $ do
     pool <- createPool cfg
     -- run migrations
-    flip runSqlPool pool $ runMigration S.migrateAll
+    flip runSqlPool pool $ runMigration S.migrateAllAuth
     -- create default admin if missing one
     _ <- runPersistentBackendT authConfig pool $ ensureAdmin 17 "admin" "123456" "admin@localhost"
     return pool

--- a/servant-auth-token-persistent/src/Servant/Server/Auth/Token/Persistent/Schema.hs
+++ b/servant-auth-token-persistent/src/Servant/Server/Auth/Token/Persistent/Schema.hs
@@ -15,7 +15,7 @@ import qualified Servant.Server.Auth.Token.Model  as M
 
 share [mkPersist sqlSettings
      , mkDeleteCascade sqlSettings
-     , mkMigrate "migrateAll"] [persistLowerCase|
+     , mkMigrate "migrateAllAuth"] [persistLowerCase|
 UserImpl
   login       Login
   password    Password     -- encrypted with salt


### PR DESCRIPTION
If integrating with a project that's also using persistent, saying
"migrateAll" is a bit of a misnomer when it's only migrating the
authentication aspects.

This isn't a huge priority, especially as it would require a major version bump.